### PR TITLE
Only enforce binfmt setup when building for different arch

### DIFF
--- a/create-targz.sh
+++ b/create-targz.sh
@@ -10,8 +10,11 @@ VER=31
 
 function build {
 # Install dependencies
-dnf -y install mock qemu-user-static
-systemctl restart systemd-binfmt.service
+dnf -y install mock
+if [ "$(uname -i)" != "$ARCH" ] ; then
+	dnf -y install qemu-user-static
+	systemctl restart systemd-binfmt.service
+fi
 
 # Move to our temporary directory
 cd $TMPDIR


### PR DESCRIPTION
This allows to build a `install.tar.gz` on a simple Fedora 31 LXC container with default configuration (e.g. on a non-Fedora host where the kernel might not support [binfmt_misc](https://en.wikipedia.org/wiki/Binfmt_misc)). The `systemd-binfmt.service` is only required for cross-architecture builds.