### PR TITLE
Redirected stderr to stdout for "which cmd.exe"

### DIFF
--- a/linux_files/00-remix.sh
+++ b/linux_files/00-remix.sh
@@ -43,7 +43,7 @@ alias clear='clear -x'
 alias ll='ls -al'
 
 # Check if we have Windows Path
-if ( which cmd.exe >/dev/null ); then
+if ( which cmd.exe >/dev/null 2>&1 ); then
 
   # Create a symbolic link to the windows home
   wHomeWinPath=$(cmd.exe /c 'echo %HOMEDRIVE%%HOMEPATH%' 2>/dev/null | tr -d '\r')


### PR DESCRIPTION
Redirected stderr to stdout (/dev/null) when which command tries to locate cmd.exe in /etc/profile.d/00-remix.sh
"""su -""" produced """which: no cmd.exe in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin)""" every time