### PR TITLE
Port 00-remix.sh to fish shell

### DIFF
--- a/create-targz.sh
+++ b/create-targz.sh
@@ -38,6 +38,7 @@ function build() {
   # Unmount /dev
   umount "${TMPDIR}"/dist/dev
 
+  mkdir -p "${TMPDIR}"/dist/etc/fish/conf.d/
   mkdir -p "${TMPDIR}"/dist/etc/fonts/
   mkdir -p "${TMPDIR}"/dist/usr/local/bin/
 
@@ -55,7 +56,9 @@ function build() {
   cp "${ORIGINDIR}"/linux_files/wsl.conf "${TMPDIR}"/dist/etc/
   cp "${ORIGINDIR}"/linux_files/local.conf "${TMPDIR}"/dist/etc/fonts/
   cp "${ORIGINDIR}"/linux_files/00-remix.sh "${TMPDIR}"/dist/etc/profile.d/
+  cp "${ORIGINDIR}"/linux_files/00-remix.fish "${TMPDIR}"/dist/etc/fish/conf.d/
   chmod -x "${TMPDIR}"/dist/etc/profile.d/00-remix.sh
+  chmod -x "${TMPDIR}"/dist/etc/fish/conf.d/00-remix.fish
 
   cp "${ORIGINDIR}"/linux_files/upgrade.sh "${TMPDIR}"/dist/usr/local/bin/
   chmod +x "${TMPDIR}"/dist/usr/local/bin/upgrade.sh

--- a/linux_files/00-remix.fish
+++ b/linux_files/00-remix.fish
@@ -1,0 +1,81 @@
+#!/usr/bin/fish
+
+# Only the default WSL user should run this script
+if not id -Gn | string match -rq 'adm.*wheel|wheel.*adm'
+    exit
+end
+
+# check whether it is WSL1 or WSL2
+if [ -n $WSL_INTEROP ]
+    #Export an environment variable for helping other processes
+    set -x WSL2 1
+    # enable external x display for WSL 2
+
+    set ipconfig_exec (wslpath 'C:\Windows\System32\ipconfig.exe')
+    if command -q ipconfig.exe
+        set ipconfig_exec (command -s ipconfig.exe)
+    end
+
+    set wsl2_d_tmp ($ipconfig_exec ^/dev/null | grep -n -m 1 "Default Gateway.*: [0-9a-z]" | cut -d : -f 1)
+
+    if [ -n $wsl2_d_tmp ]
+
+        set wsl2_d_tmp ($ipconfig_exec ^/dev/null | sed (math $wsl2_d_tmp - 4)','(math $wsl2_d_tmp + 0)'!d' | string replace -fr '^.*IPv4.*:\s*(\S+).*$' '$1')
+        set -x DISPLAY $wsl2_d_tmp:0
+    else
+        set wsl2_d_tmp (grep nameserver /etc/resolv.conf | awk '{print $2}')
+        set -x DISPLAY $wsl2_d_tmp:0
+    end
+
+    set -e wsl2_d_tmp
+    set -e ipconfig_exec
+else
+    # enable external x display for WSL 1
+    set -x DISPLAY localhost:0
+
+    # Export an environment variable for helping other processes
+    set -e WSL2
+end
+
+# enable external libgl if mesa is not installed
+if command -q glxinfo
+    set -e LIBGL_ALWAYS_INDIRECT
+else
+    set -x LIBGL_ALWAYS_INDIRECT 1
+end
+
+# if dbus-launch is installed then load it
+if command -q dbus-launch
+  set -x DBUS_SESSION_BUS_ADDRESS (timeout 2s dbus-launch sh -c 'echo "$DBUS_SESSION_BUS_ADDRESS"')
+end
+
+# speed up some GUI apps like gedit
+set -x NO_AT_BRIDGE 1
+
+# Fix 'clear' scrolling issues
+alias clear='clear -x'
+
+# Custom aliases
+# Removing ll='ls -al' since fish provides this out of the box.
+#alias ll='ls -al'
+
+# Check if we have Windows Path
+if command -q cmd.exe
+
+    # Create a symbolic link to the windows home
+
+    # Here have a issue: %HOMEDRIVE% might be using a custom set location
+    # moving cmd to where Windows is installed might help: %SYSTEMDRIVE%
+    set wHomeWinPath (cmd.exe /c 'cd %SYSTEMDRIVE%\ && echo %HOMEDRIVE%%HOMEPATH%' ^/dev/null | string replace -a \r '')
+
+    # shellcheck disable=SC2155
+    set -x WIN_HOME (wslpath -u $wHomeWinPath)
+
+    set win_home_lnk $HOME/winhome
+    if [ ! -e $win_home_lnk ]
+        ln -s -f $WIN_HOME $win_home_lnk &>/dev/null
+    end
+
+    set -e win_home_lnk
+
+end

--- a/linux_files/upgrade.sh
+++ b/linux_files/upgrade.sh
@@ -32,6 +32,8 @@ fi
 
 # Update the release and main startup script files
 sudo curl -f https://raw.githubusercontent.com/WhitewaterFoundry/Fedora-Remix-for-WSL/master/linux_files/00-remix.sh -o /etc/profile.d/00-remix.sh
+sudo mkdir -p /etc/fish/conf.d/
+sudo curl -f https://raw.githubusercontent.com/WhitewaterFoundry/Fedora-Remix-for-WSL/master/linux_files/00-remix.fish -o /etc/fish/conf.d/00-remix.fish
 
 (
   source /etc/os-release

--- a/update-targz.sh
+++ b/update-targz.sh
@@ -60,6 +60,7 @@ sudo chroot rootfs/ dnf -y clean all
 
 echo 'Copy files'
 sudo cp /vagrant/linux_files/00-remix.sh rootfs/etc/profile.d/
+sudo cp /vagrant/linux_files/00-remix.fish rootfs/etc/fish/conf.d/
 sudo cp /vagrant/linux_files/os-release-"${VERSION_ID}" rootfs/etc/
 sudo cp /vagrant/linux_files/upgrade.sh rootfs/usr/local/bin/
 sudo cp /vagrant/linux_files/local.conf rootfs/etc/fonts/


### PR DESCRIPTION
Fish shell is known for its incompatibility by design with POSIX shells. Therefore, 00-remix.sh does not run on fish shell.

It might be controversial to do this port because most fish users are able to figure out a workaround themselves without relying on the upstream, but the logic in this script is so complicated that I believe it is better to provide such a port.

(P.S.: I only tested the 00-remix.fish script itself, although I also modified the packaging scripts. If possible, please help me make sure the packaging works before merging.)

(Update: I am not sure why the CI check failed. According to the error messages, it seems that the problem is not related to this PR.)