### PR TITLE
[update.sh] Remove redundant slash from upgrade.sh URL causing HTTP 301 Moved Permanently

### DIFF
--- a/linux_files/upgrade.sh
+++ b/linux_files/upgrade.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BASE_URL="https://raw.githubusercontent.com/WhitewaterFoundry/fedora-remix-rootfs-build/master/"
+BASE_URL="https://raw.githubusercontent.com/WhitewaterFoundry/fedora-remix-rootfs-build/master"
 sha256sum /usr/local/bin/upgrade.sh >/tmp/sum.txt
 sudo curl -f "${BASE_URL}/linux_files/upgrade.sh" -o /usr/local/bin/upgrade.sh
 sudo chmod +x /usr/local/bin/upgrade.sh


### PR DESCRIPTION
The final `upgrade.sh` URL is `https://raw.githubusercontent.com/WhitewaterFoundry/fedora-remix-rootfs-build/master//linux_files/upgrade.sh` (notice double slash "/" character) which causes HTTP 301 Moved Permanently response:
```
$ curl -i https://raw.githubusercontent.com/WhitewaterFoundry/fedora-remix-rootfs-build/master//linux_files/upgrade.sh
HTTP/2 301
content-type: text/html; charset=utf-8
location: /WhitewaterFoundry/fedora-remix-rootfs-build/master/linux_files/upgrade.sh
x-github-request-id: 6D24:0DCE:7DE925:86AEDC:602B7CA8
accept-ranges: bytes
date: Tue, 16 Feb 2021 08:14:26 GMT
via: 1.1 varnish
x-served-by: cache-fra19137-FRA
x-cache: HIT
x-cache-hits: 1
x-timer: S1613463267.843925,VS0,VE0
access-control-allow-origin: *
x-fastly-request-id: b30e137cb8ae4f907e21dcf63997d6c6085bbb28
expires: Tue, 16 Feb 2021 08:19:26 GMT
source-age: 570
vary: Authorization,Accept-Encoding
content-length: 109

<a href="/WhitewaterFoundry/fedora-remix-rootfs-build/master/linux_files/upgrade.sh">Moved Permanently</a>.
```

That results in the following error after running local `upgrade.sh`:
```
$ upgrade.sh
/usr/local/bin/upgrade.sh: line 1: a: No such file or directory
```
```
$ cat /usr/local/bin/upgrade.sh
<a href="/WhitewaterFoundry/fedora-remix-rootfs-build/master/linux_files/upgrade.sh">Moved Permanently</a>.
```