### PR TITLE
Don't call cmd.exe if not needed

### DIFF
--- a/linux_files/00-remix.sh
+++ b/linux_files/00-remix.sh
@@ -69,7 +69,7 @@ alias clear='clear -x'
 alias ll='ls -al'
 
 # Check if we have Windows Path
-if (command -v cmd.exe >/dev/null 2>&1); then
+if [ -z "$WIN_HOME" ] && (command -v cmd.exe >/dev/null 2>&1); then
 
   # Create a symbolic link to the windows home
 


### PR DESCRIPTION
Hi, I found starting new subshell in WSL2 with this Fedora remix is really slow, and found the reason is caused by this 00-remix.sh, I tried to fix it, as long as WIN_HOME is not a variable that changes from time to time, this fix should be valid, please have a look.

cmd.exe is called in 00-remix.sh to get and set the WIN_HOME variable.

When spawning multiple shell instances inside a already running interactive
shell, this cmd.exe call slows down the startup speed by a lot, skip this call
if WIN_HOME is already set.