### PR TITLE
fix: metadata_expire for whitewaterfoundry repos is too short

### DIFF
--- a/linux_files/wslutilities.repo
+++ b/linux_files/wslutilities.repo
@@ -7,7 +7,7 @@ enabled=1
 gpgkey=https://packagecloud.io/whitewaterfoundry/wslu/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
+metadata_expire=30d
 
 [whitewaterfoundry_wslu-source]
 name=whitewaterfoundry_wslu-source
@@ -18,4 +18,4 @@ enabled=0
 gpgkey=https://packagecloud.io/whitewaterfoundry/wslu/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
+metadata_expire=30d


### PR DESCRIPTION
The value of `metadata_expire` was previously set to 300 (seconds?), which meant the cache was always expiring, and each `dnf` command had long waits, for a repo that rarely changes, and doesn't have proxies.

This PR sets the value to 30d, assuming that this was the original intent.
(unless it was 300d? i assume it's also possible)